### PR TITLE
Feat  retain published data types for consumer events

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,11 @@
-redis:
-  image: redis
-  container_name: cache
-  ports:
-    - 6379:6379
+version: '3'
+services:
+  redis:
+    image: redis
+    container_name: cache
+    ports:
+      - 6379:6379
+    volumes:
+      - redis-data:/var/lib/redis
+volumes:
+  redis-data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoekma/redpop",
-  "version": "0.0.2-alpha.2",
+  "version": "0.0.2-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -400,6 +400,15 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chai-datetime": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chai-datetime/-/chai-datetime-1.7.0.tgz",
+      "integrity": "sha512-4kPT3R1tr0ujZ+xRTOzvGiZOzC30URFT+28/gd/vusOhumSH/o6TVI4yZMsQTwc+UUGpvIdx1wChQQVZkTbq/g==",
+      "dev": true,
+      "requires": {
+        "chai": ">1.9.0"
       }
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoekma/redpop",
-  "version": "0.0.2-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Redis Streams Point of Presence",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
   },
   "keywords": [
     "redis",
-    "streams"
+    "streams",
+    "esb",
+    "bus",
+    "event",
+    "message"
   ],
   "author": "HoekTek, LLC",
   "license": "MIT",
@@ -34,6 +38,7 @@
     "assert": "^2.0.0",
     "babel-eslint": "^10.1.0",
     "chai": "^4.2.0",
+    "chai-datetime": "^1.7.0",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.20.2",

--- a/src/Consumer/Consumer.unit.spec.js
+++ b/src/Consumer/Consumer.unit.spec.js
@@ -5,6 +5,7 @@ const sandbox = require('sinon').createSandbox();
 const RedPop = require('../RedPop');
 const EventBatch = require('./EventBatch');
 const PendingEvents = require('./PendingEvents');
+const IdleConsumers = require('./IdleConsumers');
 const testConfig = require('./test/testConfig');
 const xreadgroupResponse = require('./test/xreadgroupResponse');
 
@@ -131,15 +132,18 @@ describe('Consumer Unit Tests', () => {
       expect(xgroupStub.calledOnce).equals(true);
     });
 
-    it.skip('starts the consumer and completes batches', async () => {
-      const xreadgroupStub = sandbox
+    it('starts the consumer and completes batches', async () => {
+      const xreadgroup = sandbox
         .stub(RedPop.prototype, 'xreadgroup')
         .resolves(null);
       const xgroupStub = sandbox.stub(RedPop.prototype, 'xgroup');
+      const idleConsumerStub = sandbox
+        .stub(IdleConsumers.prototype, 'removeIdleConsumers')
+        .resolves(null);
       const consumer = new Consumer(config);
       await consumer.start();
       expect(
-        xreadgroupStub.calledOnce,
+        xreadgroup.calledOnce,
         'xreadgroup should have been called'
       ).equals(true);
       expect(
@@ -149,6 +153,10 @@ describe('Consumer Unit Tests', () => {
       expect(
         pendingEventsStub.calledOnce,
         'pendingEventsStub should have been called'
+      ).equals(true);
+      expect(
+        idleConsumerStub.calledOnce,
+        'idleConsumerStub should have been called'
       ).equals(true);
     });
   });

--- a/src/Consumer/EventBatch/EventBatch.js
+++ b/src/Consumer/EventBatch/EventBatch.js
@@ -3,6 +3,7 @@ const BATCH_STREAM_NAME = 0;
 const BATCH_EVENTS = 1;
 const EVENT_ID = 0;
 const EVENT_PAYLOAD = 1;
+const dateRegEx = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*))(?:Z|(\+|-)([\d|:]*))?$/;
 
 class EventBatch {
   constructor(events) {
@@ -36,7 +37,18 @@ class EventBatch {
   _extractData(dataArray) {
     const dataObject = {};
     for (let dataIndex = 0; dataIndex < dataArray.length; dataIndex += 2) {
-      dataObject[dataArray[dataIndex]] = dataArray[dataIndex + 1];
+      const data = dataArray[dataIndex + 1];
+      try {
+        // try to decode json if possible. Does not work on dates.
+        dataObject[dataArray[dataIndex]] = JSON.parse(data);
+      } catch (e) {
+        if (data.match(dateRegEx)) {
+          dataObject[dataArray[dataIndex]] = new Date(Date.parse(data));
+        } else {
+          // just take the value if JSON.parse date fails.
+          dataObject[dataArray[dataIndex]] = dataArray[dataIndex + 1];
+        }
+      }
     }
     return dataObject;
   }

--- a/src/Consumer/EventBatch/EventBatch.unit.spec.js
+++ b/src/Consumer/EventBatch/EventBatch.unit.spec.js
@@ -1,14 +1,43 @@
-const { expect } = require('chai');
+const chai = require('chai');
 const EventBatch = require('./EventBatch');
 const xreadgroupResponse = require('../test/xreadgroupResponse');
 
-describe('MessgeBatch Unit Test', () => {
+chai.use(require('chai-datetime'));
+const { expect } = chai;
+
+describe('EventBatch Unit Test', () => {
   it('loads an ioredis event', () => {
     const eventBatch = new EventBatch(xreadgroupResponse);
+    const event = eventBatch.getEvents()[0];
+    const data = xreadgroupResponse[0][1][0][1];
+
     expect(eventBatch.getStreamName()).equals('redpop');
-    expect(eventBatch.getEvents()[0].id).equals(xreadgroupResponse[0][1][0][0]);
-    expect(eventBatch.getEvents()[0].data.d).equals(
-      xreadgroupResponse[0][1][0][1][1]
+    expect(event.id).equals(xreadgroupResponse[0][1][0][0]);
+
+    let field;
+
+    // validate string value
+    field = event.data.string;
+    expect(field).to.be.a('string');
+    expect(field, 'failed to parse a string').equals(JSON.parse(data[1]));
+
+    // validate number value
+    field = event.data.number;
+    expect(field, 'field should be a number').to.be.a('number');
+    expect(field, 'failed to parse a number').equals(JSON.parse(data[5]));
+
+    // validate boolean value
+    field = event.data.boolean;
+    expect(field).to.be.a('boolean');
+    expect(event.data.boolean, 'failed to parse a boolean').equals(
+      JSON.parse(data[9])
+    );
+
+    // validate date value
+    field = event.data.date;
+    expect(field, 'eventDate should be a date').to.be.a('date');
+    expect(field, 'failed to parse a date').to.equalDate(
+      new Date(Date.parse(data[7]))
     );
   });
 

--- a/src/Consumer/PendingEvents/PendingEvents.integration.spec.js
+++ b/src/Consumer/PendingEvents/PendingEvents.integration.spec.js
@@ -68,7 +68,7 @@ describe('PendingEvents Integration Tests', () => {
     const pendingMessages = await redPop.xpending();
     expect(
       isEmpty(pendingMessages),
-      'beforeEach - Pending messages should not exist'
+      'beforeEach - Pending events should not exist'
     ).equals(true);
   });
 
@@ -88,7 +88,7 @@ describe('PendingEvents Integration Tests', () => {
 
       // Verify that there is a pending message
       let pendingMessages = await consumer.xpending();
-      expect(isEmpty(pendingMessages), 'Pending messages should exist').equals(
+      expect(isEmpty(pendingMessages), 'Pending events should exist').equals(
         false
       );
 
@@ -105,7 +105,7 @@ describe('PendingEvents Integration Tests', () => {
 
       expect(
         isEmpty(pendingMessages),
-        'Pending messages should not exist'
+        'Pending events should not exist'
       ).equals(true);
     });
   });

--- a/src/Consumer/PendingEvents/PendingEvents.unit.spec.js
+++ b/src/Consumer/PendingEvents/PendingEvents.unit.spec.js
@@ -24,7 +24,7 @@ describe('PendingEvents Unit Test', () => {
     xackStub = sandbox.stub(Consumer.prototype, 'xack');
     xclaimStub = sandbox
       .stub(PendingEvents.prototype, 'xclaim')
-      .resolves(xreadgroupResponse);
+      .resolves(xreadgroupResponse[0][1]);
   });
 
   afterEach(() => {
@@ -43,6 +43,7 @@ describe('PendingEvents Unit Test', () => {
       const pendingEvents = new PendingEvents(consumer);
       pendingEvents._pendingEvents = events;
       await pendingEvents._removeMaxRetries();
+
       // this should remove the event with the 4 retries.
       expect(pendingEvents._pendingEvents.length).equals(7);
       expect(xackStub.calledOnce).equals(true);
@@ -59,6 +60,7 @@ describe('PendingEvents Unit Test', () => {
       expect(xclaimStub.calledOnce, 'xclaimStub should be called').equals(true);
     });
   });
+
   describe('PendingEvents - Negative Tests', () => {
     beforeEach(() => {
       xpendingStub = sandbox

--- a/src/Consumer/test/xreadgroupResponse.js
+++ b/src/Consumer/test/xreadgroupResponse.js
@@ -2,8 +2,40 @@ module.exports = [
   [
     'redpop',
     [
-      ['1584676949011-0', ['d', '"data"', 'j', '"json data"', 'n', '1000']],
-      ['1584676949014-0', ['d', '"data"', 'j', '"json data"', 'n', '1000']]
+      [
+        '1584676949011-0',
+        [
+          'string',
+          '"data"',
+          'json',
+          '{"uid":"4d7b14c1-3899-4204-8879-0ff7a7c89f59","email":"Reinhold_Bahringer2@gmail.com","password":"5SzkRuHeSN72Mgh","firstName":"Carlos","lastName":"Christiansen","address":"6463 Rath Streets","city":"Hayleeville","state":"RI","postalCode":"45891-1157"}',
+          'number',
+          '1000',
+          'date',
+          '2013-10-06T15:32:18.605Z',
+          'boolean',
+          'true',
+          'array',
+          '["apple", 2, true, "2013-10-06T15:32:18.605Z"]'
+        ]
+      ],
+      [
+        '1584676949011-0',
+        [
+          'string',
+          '"data"',
+          'json',
+          '{"uid":"4d7b14c1-3899-4204-8879-0ff7a7c89f59","email":"Reinhold_Bahringer2@gmail.com","password":"5SzkRuHeSN72Mgh","firstName":"Carlos","lastName":"Christiansen","address":"6463 Rath Streets","city":"Hayleeville","state":"RI","postalCode":"45891-1157"}',
+          'number',
+          '1000',
+          'date',
+          '2013-10-06T15:32:18.605Z',
+          'boolean',
+          'true',
+          'array',
+          '["apple", 2, true, "2013-10-06T15:32:18.605Z"]'
+        ]
+      ]
     ]
   ]
 ];


### PR DESCRIPTION
This version will keep the data types in the events passed to processEvent. Previously dates, boolean, and objects would be passed in as strings.